### PR TITLE
Refactor URLChecker to extract version from .deb files

### DIFF
--- a/src/checkers/urlchecker.py
+++ b/src/checkers/urlchecker.py
@@ -114,6 +114,14 @@ class URLChecker(Checker):
                     version_string = await utils.extract_appimage_version(
                         tmpfile,
                     )
+            elif url.endswith(".deb"):
+                with tempfile.NamedTemporaryFile("w+b") as tmpfile:
+                    new_version = await utils.get_extra_data_info_from_url(
+                        url, session=self.session, dest_io=tmpfile
+                    )
+                    version_string = await utils.extract_deb_version(
+                        tmpfile,
+                    )
             else:
                 new_version = await utils.get_extra_data_info_from_url(
                     url, session=self.session

--- a/src/lib/utils.py
+++ b/src/lib/utils.py
@@ -35,6 +35,7 @@ import shlex
 from pathlib import Path
 import operator
 
+from apt.debfile import DebPackage
 from collections import OrderedDict
 from ruamel.yaml import YAML
 from elftools.elf.elffile import ELFFile
@@ -447,6 +448,16 @@ async def extract_appimage_version(appimg_io: t.IO):
             kf = GLib.KeyFile()
             kf.load_from_file(str(desktop), GLib.KeyFileFlags.NONE)
             return kf.get_string(GLib.KEY_FILE_DESKTOP_GROUP, "X-AppImage-Version")
+
+
+async def extract_deb_version(deb_io: t.IO):
+    assert deb_io.name
+
+    deb = DebPackage(deb_io.name)
+    # if not deb.check():
+    #     raise ValueError("The .deb file is invalid or corrupted.")
+
+    return deb._sections.get("Version")
 
 
 _GITHUB_URL_PATTERN = re.compile(


### PR DESCRIPTION
This commit refactors the URLChecker class in the urlchecker.py file. It adds support for extracting the version from .deb files. The code now uses the `extract_deb_version` function from the utils.py file to extract the version string from the .deb file.

Refactoring the URLChecker class allows for better handling of different file types and improves the overall functionality of the code.